### PR TITLE
[FIX] account_avatax: Tax rounding not applied in Invoice

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -260,7 +260,9 @@ class AccountMove(models.Model):
 
             # Set Taxes on lines in a way that properly triggers onchanges
             # This same approach is also used by the official account_taxcloud connector
-            with Form(self) as move_form:
+            with Form(
+                self.with_context(avatax_invoice=self, check_move_validity=False)
+            ) as move_form:
                 for index, taxes in taxes_to_set:
                     with move_form.invoice_line_ids.edit(index) as line_form:
                         line_form.tax_ids.clear()


### PR DESCRIPTION
Based on: https://github.com/OCA/account-fiscal-rule/pull/313